### PR TITLE
Fix: Enable 2 different pkgs from same repo to be inspected

### DIFF
--- a/go-getx.go
+++ b/go-getx.go
@@ -80,7 +80,7 @@ func main() {
 		}
 
 		if *install {
-			goCtx := gocmd.New(format, goPath, *buildFlags, goFlags...)
+			goCtx := gocmd.New(format, goPath, "", *buildFlags, goFlags...)
 			ok := true
 			for _, pkg := range *pkgs {
 				err := goCtx.Install(".", pkg)


### PR DESCRIPTION
Previously, if some package relied on 2 different packages in a single remote repo, go-getx would would do a clone and inspect on the first package but would take the mere existence of the second package on disk as evidence that we did not need to do an inspection. As a result, dependencies of the second package would not be retrieved and the final go install of the first package would fail.

The primary fix here is treat the fact that a package is newly cloned as a reason (despite other flags) for itself to be inspected. To achieve this I reworked some parts to split the current 'done' tracking to differentiate between 'cloned', '[go-]listed' and 'inspected'.