### PR TITLE
Fix: Ensure when retrieving 2 packages from dep repo

### DIFF
--- a/getx/getx.go
+++ b/getx/getx.go
@@ -144,12 +144,8 @@ func (c *Context) AlreadyDoneGit(pkg string) bool {
 }
 
 func (c *Context) AlreadyDoneGo(pkg string) bool {
-	for donePkg, _ := range c.doneGo {
-		if pkgContains(donePkg, pkg) {
-			return true
-		}
-	}
-	return false
+	_, ok := c.doneGo[pkg]
+	return ok
 }
 
 func stringInSlice(slice []string, s string) bool {


### PR DESCRIPTION
When pulling 2 separate pkgs from the same remote repo, only the first one is scanned for further deps. As a result, not all the required dependencies are acquired.